### PR TITLE
Use per-file creation date

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,56 @@
-For deleting to work you must add the following to `System Settings | Privacy & Security | Full Disk Access` by clicking `+` and pressing key command `⌘⇧G` to paste in those paths.
+# Recompress BodyCam Quick Action
+
+A macOS Shortcuts Quick Action that re‑encodes body camera footage using `ffmpeg`. Each selected clip becomes an AV1 file with Opus audio and is stored in a dated `yyyymmdd` folder. The date comes from the clip's `creation_time` metadata when present, or else from the file creation time. Tested on **macOS 15.5 (24F74)**.
+
+## Features
+- Fast AV1 (`libsvtav1`) video encoding
+- Compact `libopus` audio
+- Output clips stored in `yyyymmdd` folders based on each clip's recording date
+- Encoded files are saved alongside a log as `<original>_av1.mp4`
+- Uses video metadata `creation_time` when available for folder naming
+- Optional deletion of the originals after verification
+- Desktop notifications with progress information
+
+## Requirements
+- macOS 15.5 or newer
+- [`ffmpeg`](https://ffmpeg.org/) compiled with `libsvtav1` and `libopus` support (`brew install ffmpeg`)
+- Permission to run shell scripts from the Shortcuts app
+
+## Installation
+1. Clone this repository or copy `shortcuts.sh`.
+2. In the **Shortcuts** app, create a new **Quick Action** with a **Run Shell Script** step.
+3. Set the shell to `/bin/zsh` and configure it to pass input as *arguments*.
+4. Paste the contents of `shortcuts.sh` into the script field.
+5. (Optional) Prepend an output folder path before the *Shortcut Input* variable to bypass the folder picker.
+6. Save the Quick Action so it appears in Finder when files are selected.
+
+## Grant Full Disk Access
+The script deletes the original files once the new versions are confirmed. For this to work, grant **Full Disk Access** to the following in **System Settings → Privacy & Security → Full Disk Access** (use **⌘⇧G** to jump to each path):
+
 - `/System/Library/CoreServices/Finder.app`
 - `/System/Library/PrivateFrameworks/WorkflowKit.framework/XPCServices/BackgroundShortcutRunner.xpc/Contents/MacOS/BackgroundShortcutRunner`
 - `/System/Library/PrivateFrameworks/WorkflowKit.framework/XPCServices/ShortcutsMacHelper.xpc/Contents/MacOS/ShortcutsMacHelper`
+
+## Usage
+1. Select one or more bodycam video files in Finder.
+2. Right‑click and choose **Recompress BodyCam**.
+3. Pick an output folder when prompted, or supply it as the first argument in the Quick Action to skip the picker.
+4. Each clip is transcoded to `<original>_av1.mp4` inside a `yyyymmdd` folder named after its recording date.
+5. A log file is created in the output directory summarizing the run.
+
+## Customization
+The first argument to `shortcuts.sh` is the destination folder. When running from Shortcuts, leave this argument blank to display the folder picker, or supply a path (e.g. `/Users/me/BodycamAV1`) before the *Shortcut Input* variable to use a fixed location. Adjust the encoding parameters in the script as needed for your workflow.
+
+## Testing
+An integration test script for macOS is provided as `macos-test.sh`. It runs
+`shortcuts.sh` directly with a temporary clip and verifies that the re‑encoded
+file is produced.
+
+```bash
+./macos-test.sh
+```
+
+Run it on a Mac with `ffmpeg` and zsh available.
+
+## License
+This project is available under the [MIT License](LICENSE).

--- a/macos-test.sh
+++ b/macos-test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Integration test for the "Recompress BodyCam" Quick Action.
+# Requires macOS with zsh, ffmpeg and (optionally) the Shortcuts CLI.
+
+tmpdir=$(mktemp -d)
+outdir=$(mktemp -d)
+cleanup() { rm -rf "$tmpdir" "$outdir"; }
+trap cleanup EXIT
+
+# Generate two 1‑second sample clips with different metadata
+ffmpeg -f lavfi -i testsrc=size=320x240:duration=1 -metadata creation_time="2024-01-01T12:00:00Z" -c:v libx264 -t 1 "$tmpdir/in1.mov" -y >/dev/null 2>&1
+ffmpeg -f lavfi -i testsrc=size=320x240:duration=1 -metadata creation_time="2024-01-02T12:00:00Z" -c:v libx264 -t 1 "$tmpdir/in2.mov" -y >/dev/null 2>&1
+
+# Run the script directly with the output directory
+zsh shortcuts.sh "$outdir" "$tmpdir/in1.mov" "$tmpdir/in2.mov"
+
+# Verify that an output clip was produced
+found1="$outdir/20240101/in1_av1.mp4"
+found2="$outdir/20240102/in2_av1.mp4"
+if [[ -f "$found1" && -f "$found2" ]]; then
+  echo "✅ Both output files created"
+else
+  echo "❌ Output files not found" >&2
+  exit 1
+fi
+
+# Check that a log file exists in the output root directory
+logfile=$(find "$outdir" -maxdepth 1 -name '*.log' | head -n 1 || true)
+if [[ -f "$logfile" ]]; then
+  echo "✅ Log file created at $logfile"
+else
+  echo "❌ Log file not found" >&2
+  exit 1
+fi
+

--- a/shortcuts.sh
+++ b/shortcuts.sh
@@ -1,17 +1,34 @@
 #!/usr/bin/env zsh
 set -eux
 
-LOGFILE="/Users/nashspence/Desktop/BodyCam-Reencode-$(date +'%Y%m%dT%H%M%S').log"
-touch "$LOGFILE" 2>/dev/null || { echo "❌ Cannot write to log file '$LOGFILE'." >&2; exit 1; }
-exec 2>>"$LOGFILE"
-osascript -e "tell application \"Terminal\" to do script \"tail -f '$LOGFILE'\""
-echo "▶ Script started at $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >&2
-trap 'ret=$?; echo "▶ Script exited with code $ret at $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >&2' EXIT
 export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 
 notify() {
   osascript -e "display notification \"$*\" with title \"BodyCam Re-encode\""
 }
+
+# Return the creation timestamp of a file as seconds since epoch. Prefer the
+# embedded `creation_time` metadata and fall back to the filesystem timestamp.
+creation_epoch_for() {
+  local f="$1"
+  local meta
+  meta=$(ffprobe -v quiet -show_entries format_tags=creation_time -of default=noprint_wrappers=1:nokey=1 "$f" 2>/dev/null | head -n 1 || true)
+  if [[ -n "$meta" ]]; then
+    meta="${meta%Z}"
+    meta="${meta%.*}"
+    if date -j -f "%Y-%m-%dT%H:%M:%S%z" "$meta" +%s 2>/dev/null; then
+      return
+    fi
+  fi
+  stat -f %B "$f"
+}
+
+out_root="${1:-}"
+if [[ -z "$out_root" || ! -d "$out_root" ]]; then
+  out_root=$(osascript -e 'POSIX path of (choose folder with prompt "Select output directory for re-encoded clips")')
+else
+  shift
+fi
 
 FILES=( "$@" )
 if (( ${#FILES[@]} == 0 )); then
@@ -21,21 +38,15 @@ if (( ${#FILES[@]} == 0 )); then
 fi
 
 # ───────────────────────────────────────────────────────────────────────────────
-# Instead of extracting “datepart” from the filename, get the filesystem creation date
-# of the first selected file (e.g. 2025-06-03 → “2025_0603”).
-firstfile="${FILES[1]}"
+# Setup logging in the chosen output directory. Each clip will be placed in a
+# subfolder based on its individual creation time.
 
-# Use stat to fetch the file’s creation timestamp (in seconds since epoch)
-creation_epoch=$(stat -f %B "$firstfile")
-
-# Format that timestamp as YYYY_MMDD (same pattern as “2025_0603”)
-datepart=$(date -r "$creation_epoch" +"%Y_%m%d")
-
-target_dir="/Volumes/Sabrent Rocket XTRM-Q 2TB/bodycam/$datepart"
-
-# Create the directory if it doesn't already exist
-mkdir -p "$target_dir"
-echo "▶ Created (or verified) directory: $target_dir" >&2
+LOGFILE="$out_root/BodyCam-Reencode-$(date +'%Y%m%dT%H%M%S').log"
+touch "$LOGFILE" 2>/dev/null || { echo "❌ Cannot write to log file '$LOGFILE'." >&2; exit 1; }
+exec 2>>"$LOGFILE"
+osascript -e "tell application \"Terminal\" to do script \"tail -f '$LOGFILE'\""
+echo "▶ Script started at $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >&2
+trap 'ret=$?; echo "▶ Script exited with code $ret at $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >&2' EXIT
 # ───────────────────────────────────────────────────────────────────────────────
 
 cd -- "$(dirname -- "${FILES[1]}")"
@@ -46,9 +57,13 @@ notify "Re-encoding ${#FILES[@]} clips…"
 
 index=1
 for file_i in "${FILES[@]}"; do
+  creation_epoch=$(creation_epoch_for "$file_i")
+  datepart=$(date -r "$creation_epoch" +"%Y%m%d")
+  target_dir="$out_root/$datepart"
+  mkdir -p "$target_dir"
   base_name="${file_i##*/}"
   base_name="${base_name%.*}"
-  outname="${base_name}_recompressed_av1.mp4"
+  outname="${base_name}_av1.mp4"
   outpath="$target_dir/$outname"
 
   echo "[$index/${#FILES[@]}] '$file_i' → '$outpath'" >&1
@@ -71,11 +86,11 @@ for file_i in "${FILES[@]}"; do
 done
 
 echo "" >&1
-echo "▶ Transcoding complete. Generated files in $target_dir:" >&1
-printf "    %s\n" "$target_dir"/*_recompressed_av1.mp4 >&1
+echo "▶ Transcoding complete. Generated files:" >&1
+find "$out_root" -name '*_av1.mp4' -print | sed 's/^/    /'
 echo "" >&1
 
-notify "Deleted original files; re-encoded clips are in $datepart"
+notify "Deleted original files; re-encoded clips are in subfolders"
 echo "--------------------------------------" >>"$LOGFILE"
 echo "Completed successfully at $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >>"$LOGFILE"
 echo "Log file is: $LOGFILE" >>"$LOGFILE"


### PR DESCRIPTION
## Summary
- log file now saved in chosen output directory
- determine creation date for each file individually
- store each encoded clip in its own yyyymmdd folder
- update test script for multiple input files
- expand README usage info
- rename output files with `_av1.mp4`

## Testing
- `bash -n shortcuts.sh`
- `bash -n macos-test.sh`
- `bash macos-test.sh` *(fails: ffmpeg not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a14ac3b1c832b83f91943b6a21271