### PR TITLE
Set up CI with agent guidelines

### DIFF
--- a/.github/workflows/macos-integration.yml
+++ b/.github/workflows/macos-integration.yml
@@ -1,0 +1,18 @@
+name: macOS Integration
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  integration:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install ffmpeg
+      - name: Run integration test
+        run: bash macos-test.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg zsh
+      - name: Run test script
+        run: bash tests/test_shortcuts.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions
+- **Do not run the test suite locally.** GitHub Actions executes all tests automatically. Try to have tests for all features. Try to keep features as small as possible while still providing meaningful value.
+- Add or update tests directly in the repository—CI will run them whenever a pull request is opened.
+- Avoid invoking test runners or integration scripts during local development unless for your own exploration.
+- Each viable feature should be documented in the features list section in the README.md and have a matching test with the same name and a direct link to that test file.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,12 @@
 A macOS Shortcuts Quick Action that re‑encodes body camera footage using `ffmpeg`. Each selected clip becomes an AV1 file with Opus audio and is stored in a dated `yyyymmdd` folder. The date comes from the clip's `creation_time` metadata when present, or else from the file creation time. Tested on **macOS 15.5 (24F74)**.
 
 ## Features
-- Fast AV1 (`libsvtav1`) video encoding
-- Compact `libopus` audio
-- Output clips stored in `yyyymmdd` folders based on each clip's recording date
-- Encoded files are saved alongside a log as `<original>_av1.mp4`
-- Uses video metadata `creation_time` when available for folder naming
-- Optional deletion of the originals after verification (set `KEEP_ORIGINALS=1` to preserve)
-- Desktop notifications with progress information
+- [**creates output files**](tests/test_shortcuts.sh#L87-L96) — writes `<original>_av1.mp4` in a `yyyymmdd` folder
+  next to the log file.
+- [**removes originals after second run**](tests/test_shortcuts.sh#L98-L104) — deletes the source clips once
+  the new versions are verified.
+- [**writes log files**](tests/test_shortcuts.sh#L106-L114) — records a summary of each run in the output
+  directory.
 
 ## Requirements
 - macOS 15.5 or newer


### PR DESCRIPTION
## Summary
- add AGENTS instructions
- document tested features in README
- run integration test on macOS and Linux via GitHub Actions

## Testing
- `bash tests/test_shortcuts.sh`

------
https://chatgpt.com/codex/tasks/task_e_685072c044c4832bb3e8d6861b667489