### PR TITLE
Allow customizing low motion detection thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A macOS Shortcuts Quick Action that re‑encodes body camera footage using `ffmp
   the new versions are verified.
  - [**writes log files**](tests/test_shortcuts.sh#L50-L58) — records a summary of each run in the output
   directory.
- - [**audio only for low motion**](tests/test_audio_only_for_low_motion.sh#L11-L27) — segments with minimal movement are split into audio-only files
+ - [**audio only for low motion**](tests/test_audio_only_for_low_motion.sh#L11-L34) — segments with minimal movement are split into audio-only files
 
 ## Requirements
 - macOS 15.5 or newer

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Set `KEEP_ORIGINALS=1` to preserve the source clips instead of deleting them onc
 
 Adjust the encoding parameters in the script as needed for your workflow.
 
+Set `LOW_MOTION_SAD` to modify the scene-change sensitivity when detecting low
+motion. Adjust `LOW_MOTION_MIN_LEN` (in seconds) to control how long a
+low-motion span must be before it's extracted as audio only.
+
 ## Testing
 An integration test script for macOS is provided as `macos-test.sh`. It runs
 `shortcuts.sh` directly with a temporary clip and verifies that the re‑encoded

--- a/shortcuts.sh
+++ b/shortcuts.sh
@@ -22,21 +22,22 @@ detect_low_motion() {
   duration=$(ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "$input")
   awk -v dur="$duration" -v min_len="$min_len" '
     {
-      if (match($0, /pts_time:([0-9.]+)/, m)) {
-        t=m[1]
-        if (start=="") start=t
-        if (prev!="" && t-prev>1) {
-          if (prev-start>=min_len) print start":"prev
-          start=t
+      if ($0 ~ /pts_time:[0-9.]+/) {
+        match($0, /pts_time:[0-9.]+/)
+        t = substr($0, RSTART + 9, RLENGTH - 9)
+        if (start == "") start = t
+        if (prev != "" && t - prev > 1) {
+          if (prev - start >= min_len) print start ":" prev
+          start = t
         }
-        prev=t
-        last=t
+        prev = t
+        last = t
       }
     }
     END {
-      if (prev!="" && last-start>=min_len) {
-        end = (last<dur ? last : dur)
-        print start":"end
+      if (prev != "" && last - start >= min_len) {
+        end = (last < dur ? last : dur)
+        print start ":" end
       }
     }
   ' "$tmp"

--- a/shortcuts.sh
+++ b/shortcuts.sh
@@ -21,18 +21,16 @@ detect_low_motion() {
     -vsync 0 -an -f null - >/dev/null 2>&1 || true
   duration=$(ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "$input")
   awk -v dur="$duration" -v min_len="$min_len" -v gap=0.5 '
-    {
-      if ($0 ~ /pts_time:[0-9.]+/) {
-        match($0, /pts_time:([0-9.]+)/, a)
-        t = a[1]
-        if (start == "") start = t
-        if (prev != "" && t - prev > gap) {
-          if (prev - start >= min_len) print start ":" prev
-          start = t
-        }
-        prev = t
-        last = t
+    /pts_time:/ {
+      sub(/^.*pts_time:/, "")
+      t = $0
+      if (start == "") start = t
+      if (prev != "" && t - prev > gap) {
+        if (prev - start >= min_len) print start ":" prev
+        start = t
       }
+      prev = t
+      last = t
     }
     END {
       if (prev != "" && last - start >= min_len) {

--- a/shortcuts.sh
+++ b/shortcuts.sh
@@ -2,9 +2,7 @@
 set -eux
 
 # Prevent macOS from sleeping while this script runs
-if command -v caffeinate >/dev/null 2>&1; then
-  caffeinate -dimsu -w $$ &
-fi
+caffeinate -dimsu -w $$ &
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 

--- a/shortcuts.sh
+++ b/shortcuts.sh
@@ -6,18 +6,34 @@ caffeinate -dimsu -w $$ &
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 
-# Detect low-motion segments using ffmpeg's freezedetect filter. Any freeze
-# longer than 20 seconds is returned as "start:end" pairs on stdout.
-detect_freezes() {
+# Detect low-motion segments using ffmpeg's scene score. Both the SAD threshold
+# and minimum segment length can be configured via `LOW_MOTION_SAD` and
+# `LOW_MOTION_MIN_LEN` environment variables.
+detect_low_motion() {
   local input="$1" tmp duration
+  local sad_thresh="${LOW_MOTION_SAD:-0.003}"
+  local min_len="${LOW_MOTION_MIN_LEN:-20}"
   tmp=$(mktemp)
   ffmpeg -hide_banner -loglevel info -i "$input" \
-    -vf freezedetect=n=0.003:d=20 -an -f null - 2>"$tmp" || true
+    -vf "select='lt(scene,${sad_thresh})',metadata=print:file=$tmp" \
+    -vsync 0 -an -f null - >/dev/null 2>&1 || true
   duration=$(ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "$input")
-  awk -v dur="$duration" '
-    /freeze_start/ {start=$NF}
-    /freeze_end/   {print start":"$NF; start=""}
-    END { if (start != "") print start":"dur }
+  awk -v dur="$duration" -v min_len="$min_len" '
+    /pts_time:/ {
+      split($NF,a,":"); t=a[2];
+      if (start=="") start=t;
+      if (prev!="" && t-prev>1) {
+        if (prev-start>=min_len) print start":"prev;
+        start=t
+      }
+      prev=t; last=t
+    }
+    END {
+      if (prev!="" && last-start>=min_len) {
+        end = (last<dur ? last : dur);
+        print start":"end
+      }
+    }
   ' "$tmp"
   rm -f "$tmp"
 }
@@ -27,24 +43,25 @@ iso_utc() {
   date -u -r "$1" +"%Y-%m-%dT%H:%M:%SZ"
 }
 
-# Encode a file while splitting low-motion segments into audio-only files. Each
-# freeze longer than 20 seconds becomes its own `.m4a` file with accurate
-# `creation_time`. Video resumes in numbered parts with adjusted timestamps.
+# Encode a file while splitting low-motion segments into audio-only files. Any
+# span of minimal movement lasting at least `LOW_MOTION_MIN_LEN` seconds becomes
+# its own `.m4a` file with accurate `creation_time`. Video resumes in numbered
+# parts with adjusted timestamps.
 encode_with_low_motion() {
   local input="$1" output="$2" base_epoch="$3"
-  local width height duration start end prev seg_idx freeze_idx part
+  local width height duration start end prev seg_idx low_idx part
   width=$(ffprobe -v error -select_streams v:0 -show_entries stream=width -of csv=p=0 "$input")
   height=$(ffprobe -v error -select_streams v:0 -show_entries stream=height -of csv=p=0 "$input")
   duration=$(ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "$input")
-  local -a freezes
-  IFS=$'\n' freezes=($(detect_freezes "$input"))
+  local -a low_segments
+  IFS=$'\n' low_segments=($(detect_low_motion "$input"))
 
   local base="${output%.*}" ext="${output##*.}"
   prev=0
   seg_idx=1
-  freeze_idx=1
+  low_idx=1
 
-  if (( ${#freezes[@]} == 0 )); then
+  if (( ${#low_segments[@]} == 0 )); then
     ffmpeg -hide_banner -loglevel warning -stats -y \
       -i "$input" \
       -map 0:v:0 -map 0:a:0 \
@@ -58,7 +75,7 @@ encode_with_low_motion() {
     return
   fi
 
-  for seg in "${freezes[@]}"; do
+  for seg in "${low_segments[@]}"; do
     start=${seg%:*}
     end=${seg#*:}
     if (( $(echo "$start > $prev" | bc -l) )); then
@@ -82,8 +99,8 @@ encode_with_low_motion() {
       -c:a aac -b:a 32k \
       -metadata creation_time="$(iso_utc $(printf '%.0f' $(echo "$base_epoch + $start" | bc -l)))" \
       -movflags use_metadata_tags \
-      "${base}_freeze${freeze_idx}.m4a"
-    freeze_idx=$((freeze_idx+1))
+      "${base}_lowmotion${low_idx}.m4a"
+    low_idx=$((low_idx+1))
     prev=$end
   done
 

--- a/shortcuts.sh
+++ b/shortcuts.sh
@@ -2,7 +2,9 @@
 set -eux
 
 # Prevent macOS from sleeping while this script runs
-caffeinate -dimsu -w $$ &
+if command -v caffeinate >/dev/null 2>&1; then
+  caffeinate -dimsu -w $$ &
+fi
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 

--- a/tests/test_audio_only_for_low_motion.sh
+++ b/tests/test_audio_only_for_low_motion.sh
@@ -8,14 +8,14 @@ outdir=$(mktemp -d)
 cleanup() { rm -rf "$tmpdir" "$outdir"; }
 trap cleanup EXIT
 
-# Create video with a long freeze section (>20s)
+# Create video with a long low-motion section (>20s)
 ffmpeg -f lavfi -i testsrc=size=320x240:rate=30:duration=1 -f lavfi -i color=black:size=320x240:duration=25 -f lavfi -i sine=frequency=440:duration=26 \
   -filter_complex "[0:v][1:v]concat=n=2:v=1:a=0,format=yuv420p[v]" -map "[v]" -map 2:a \
   -metadata creation_time='2024-01-03T12:00:00Z' -c:v libx264 -c:a aac -shortest "$tmpdir/in.mov" -y >/dev/null 2>&1
 
  (cd "$root_dir" && DISABLE_UI=1 zsh shortcuts.sh "$outdir" "$tmpdir/in.mov")
 
-audiofile=$(find "$outdir" -name '*freeze1.m4a' | head -n 1)
+audiofile=$(find "$outdir" -name '*lowmotion1.m4a' | head -n 1)
  videofile=$(find "$outdir" -name '*_av1.mp4' | head -n 1)
  audio_ct=$(ffprobe -v quiet -show_entries format_tags=creation_time -of csv=p=0 "$audiofile")
  video_ct=$(ffprobe -v quiet -show_entries format_tags=creation_time -of csv=p=0 "$videofile")

--- a/tests/test_audio_only_for_low_motion.sh
+++ b/tests/test_audio_only_for_low_motion.sh
@@ -13,15 +13,22 @@ ffmpeg -f lavfi -i testsrc=size=320x240:rate=30:duration=1 -f lavfi -i color=bla
   -filter_complex "[0:v][1:v]concat=n=2:v=1:a=0,format=yuv420p[v]" -map "[v]" -map 2:a \
   -metadata creation_time='2024-01-03T12:00:00Z' -c:v libx264 -c:a aac -shortest "$tmpdir/in.mov" -y >/dev/null 2>&1
 
- (cd "$root_dir" && DISABLE_UI=1 zsh shortcuts.sh "$outdir" "$tmpdir/in.mov")
+ (cd "$root_dir" && DISABLE_UI=1 LOW_MOTION_SAD=0.0001 \
+  zsh shortcuts.sh "$outdir" "$tmpdir/in.mov")
 
 audiofile=$(find "$outdir" -name '*lowmotion1.m4a' | head -n 1)
  videofile=$(find "$outdir" -name '*_av1.mp4' | head -n 1)
  audio_ct=$(ffprobe -v quiet -show_entries format_tags=creation_time -of csv=p=0 "$audiofile")
  video_ct=$(ffprobe -v quiet -show_entries format_tags=creation_time -of csv=p=0 "$videofile")
- if [[ -f "$audiofile" && "$audio_ct" == '2024-01-03T12:00:01Z' && "$video_ct" == '2024-01-03T12:00:00Z' ]]; then
+  if [[ -f "$audiofile" && "$audio_ct" == '2024-01-03T12:00:01Z' && "$video_ct" == '2024-01-03T12:00:00Z' ]]; then
    echo "✅ audio only for low motion"
- else
+  else
    echo "❌ low motion segment handling failed" >&2
+   logfile=$(ls "$outdir"/BodyCam-Reencode-*.log 2>/dev/null | head -n 1)
+   if [[ -f "$logfile" ]]; then
+     echo "--- log tail ---" >&2
+     tail -n 5 "$logfile" >&2
+     echo "---------------" >&2
+   fi
    exit 1
- fi
+  fi


### PR DESCRIPTION
## Summary
- make low motion SAD and duration thresholds configurable via `LOW_MOTION_SAD` and `LOW_MOTION_MIN_LEN`
- rename freeze variables and audio output names for clarity
- document new variables

## Testing
- `bash tests/test_audio_only_for_low_motion.sh` *(fails: `ffmpeg: command not found`)*
- `bash tests/test_shortcuts.sh` *(fails: `ffmpeg: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685154b9fd7c832b804a7ce0d8a7e462